### PR TITLE
Rewrite webcash crate to provide a more type-safe interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,7 @@ base64 = "0.13.0"
 chrono = "0.4.19"
 log = "0.4.17"
 pretty_env_logger = "0.4.0"
-primitive-types = "0.11.1"
-rust_decimal = "1.23"
+primitive-types = { version = "0.11.1", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.81", features = ["arbitrary_precision"] }
 sha2 = "0.10.2"

--- a/src/bin/webcashd.rs
+++ b/src/bin/webcashd.rs
@@ -11,7 +11,8 @@ use thousands::Separable;
 extern crate log;
 use serde::{Deserialize, Serialize};
 use webcash::{
-    Amount, CheckForDuplicates, PublicWebcash, SecretWebcash, SumAmounts, WebcashEconomy, WEBCASH_DECIMALS
+    Amount, CheckForDuplicates, PublicWebcash, SecretWebcash, SumAmounts, WebcashEconomy,
+    WEBCASH_DECIMALS,
 };
 
 const DEFAULT_RUST_LOG: &str = "info,actix_server=warn";
@@ -142,7 +143,10 @@ async fn replace(
         return json_replace_response(JSON_STATUS_ERROR, "Amount mismatch.");
     }
 
-    if [inputs.as_slice(), outputs.as_slice()].concat().contains_duplicates() {
+    if [inputs.as_slice(), outputs.as_slice()]
+        .concat()
+        .contains_duplicates()
+    {
         return json_replace_response(JSON_STATUS_ERROR, "Duplicate webcash.");
     }
 
@@ -197,11 +201,10 @@ async fn stats(data: web::Data<WebcashApplicationState>) -> impl Responder {
     web::Json(StatsResponse {
         // NOTE: Emulating Python server here by returning a truncated amount.
         //       Will be inexact in the future.
-        circulation_formatted: (
-                webcash_economy.get_total_circulation() / 10_u128.pow(WEBCASH_DECIMALS)
-            ).separate_with_commas(),
-        circulation: webcash_economy
-            .get_total_circulation() / 10_u128.pow(WEBCASH_DECIMALS),
+        circulation_formatted: (webcash_economy.get_total_circulation()
+            / 10_u128.pow(WEBCASH_DECIMALS))
+        .separate_with_commas(),
+        circulation: webcash_economy.get_total_circulation() / 10_u128.pow(WEBCASH_DECIMALS),
         difficulty_target_bits: webcash_economy.get_difficulty_target_bits(),
         ratio: webcash_economy.get_ratio(),
         mining_amount: webcash_economy.get_mining_amount(),
@@ -473,7 +476,7 @@ async fn health_check(
             JSON_STATUS_ERROR,
             "Requested number of public webcash to check exceeds maximum limit.",
             std::collections::HashMap::default(),
-        )
+        );
     }
     let webcash_economy = &mut data.webcash_economy.lock().unwrap();
     let mut results = std::collections::HashMap::<String, HealthCheckSpentResponse>::default();

--- a/src/bin/webcashd.rs
+++ b/src/bin/webcashd.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2022 Webcash Developers
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use actix_web::{
     get, http::header::ContentType, post, web, App, HttpResponse, HttpServer, Responder,
 };

--- a/src/bin/webcashd.rs
+++ b/src/bin/webcashd.rs
@@ -9,8 +9,10 @@ use actix_web::{
 use thousands::Separable;
 #[macro_use]
 extern crate log;
-use rust_decimal::prelude::*;
 use serde::{Deserialize, Serialize};
+use webcash::{
+    Amount, CheckForDuplicates, PublicWebcash, SecretWebcash, SumAmounts, WebcashEconomy, WEBCASH_DECIMALS
+};
 
 const DEFAULT_RUST_LOG: &str = "info,actix_server=warn";
 
@@ -85,8 +87,8 @@ struct LegaleseRequest {
 #[derive(Deserialize)]
 struct ReplaceRequest {
     legalese: LegaleseRequest,
-    webcashes: Vec<String>,
-    new_webcashes: Vec<String>,
+    webcashes: Vec<SecretWebcash>,
+    new_webcashes: Vec<SecretWebcash>,
 }
 
 #[derive(Serialize)]
@@ -120,36 +122,28 @@ async fn replace(
         return json_replace_response(JSON_STATUS_ERROR, "Terms of service not accepted.");
     }
 
-    let inputs = match webcash::parse_webcash_tokens(
-        &replace_request.webcashes,
-        &webcash::WebcashTokenKind::Secret,
-        MAX_REPLACEMENT_INPUT_TOKENS,
-    ) {
-        Ok(inputs) => inputs,
-        Err(_) => return json_replace_response(JSON_STATUS_ERROR, "Invalid input(s)."),
-    };
-    assert_eq!(inputs.len(), replace_request.webcashes.len());
-    assert!(inputs
-        .iter()
-        .all(|wc| wc.token_kind == webcash::WebcashTokenKind::Secret));
+    let inputs = &replace_request.webcashes;
+    if inputs.is_empty() {
+        return json_replace_response(JSON_STATUS_ERROR, "Must specify input webcashes.");
+    }
+    if MAX_REPLACEMENT_INPUT_TOKENS < inputs.len() {
+        return json_replace_response(JSON_STATUS_ERROR, "Number of inputs exceeds maximum limit.");
+    }
 
-    let outputs = match webcash::parse_webcash_tokens(
-        &replace_request.new_webcashes,
-        &webcash::WebcashTokenKind::Secret,
-        MAX_REPLACEMENT_OUTPUT_TOKENS,
-    ) {
-        Ok(outputs) => outputs,
-        Err(_) => return json_replace_response(JSON_STATUS_ERROR, "Invalid output(s)."),
-    };
-    assert_eq!(outputs.len(), replace_request.new_webcashes.len());
-    assert!(outputs
-        .iter()
-        .all(|wc| wc.token_kind == webcash::WebcashTokenKind::Secret));
+    let outputs = &replace_request.new_webcashes;
+    if outputs.is_empty() {
+        return json_replace_response(JSON_STATUS_ERROR, "Must specify output webcashes.");
+    }
+    if MAX_REPLACEMENT_OUTPUT_TOKENS < outputs.len() {
+        return json_replace_response(JSON_STATUS_ERROR, "Number of inputs exceeds maximum limit.");
+    }
 
-    let total_input = webcash::sum(&inputs);
-    let total_output = webcash::sum(&outputs);
-    if total_input != total_output {
+    if inputs.total_value() != outputs.total_value() {
         return json_replace_response(JSON_STATUS_ERROR, "Amount mismatch.");
+    }
+
+    if [inputs.as_slice(), outputs.as_slice()].concat().contains_duplicates() {
+        return json_replace_response(JSON_STATUS_ERROR, "Duplicate webcash.");
     }
 
     let webcash_economy = &mut data.webcash_economy.lock().unwrap();
@@ -164,9 +158,9 @@ async fn replace(
 struct TargetResponse {
     difficulty_target_bits: u8,
     ratio: f32,
-    mining_amount: String,
-    mining_subsidy_amount: String,
-    epoch: u32,
+    mining_amount: Amount,
+    mining_subsidy_amount: Amount,
+    epoch: usize,
 }
 
 #[get("/api/v1/target")]
@@ -177,8 +171,8 @@ async fn target(data: web::Data<WebcashApplicationState>) -> impl Responder {
     web::Json(TargetResponse {
         difficulty_target_bits: webcash_economy.get_difficulty_target_bits(),
         ratio: webcash_economy.get_ratio(),
-        mining_amount: webcash_economy.get_mining_amount().to_string(),
-        mining_subsidy_amount: webcash_economy.get_subsidy_amount().to_string(),
+        mining_amount: webcash_economy.get_mining_amount(),
+        mining_subsidy_amount: webcash_economy.get_subsidy_amount(),
         epoch: webcash_economy.get_epoch(),
     })
 }
@@ -186,13 +180,13 @@ async fn target(data: web::Data<WebcashApplicationState>) -> impl Responder {
 #[derive(Serialize)]
 struct StatsResponse {
     circulation_formatted: String, // NOTE: Inexact. Live environment does not use decimals here. Uses integers?
-    circulation: u64, // NOTE: Inexact. Live environment does not use decimals here. Uses integers?
+    circulation: u128, // NOTE: Inexact. Live environment does not use decimals here. Uses integers?
     difficulty_target_bits: u8,
-    ratio: f64,            // TODO/FIX: float here but string (decimal) in target API call.
-    mining_amount: String, // NOTE: Live environment has "mining_amount": "50000.0", "mining_subsidy_amount": "2500.00". Different granularity?
-    mining_subsidy_amount: String, // NOTE: Live environment has "mining_amount": "50000.0", "mining_subsidy_amount": "2500.00". Different granularity?
-    epoch: u32,
-    mining_reports: u32,
+    ratio: f32,            // TODO/FIX: float here but string (decimal) in target API call.
+    mining_amount: Amount, // NOTE: Live environment has "mining_amount": "50000.0", "mining_subsidy_amount": "2500.00". Different granularity?
+    mining_subsidy_amount: Amount, // NOTE: Live environment has "mining_amount": "50000.0", "mining_subsidy_amount": "2500.00". Different granularity?
+    epoch: usize,
+    mining_reports: usize,
 }
 
 #[get("/stats")]
@@ -201,21 +195,17 @@ struct StatsResponse {
 async fn stats(data: web::Data<WebcashApplicationState>) -> impl Responder {
     let webcash_economy = &mut data.webcash_economy.lock().unwrap();
     web::Json(StatsResponse {
-        circulation_formatted: webcash_economy
-            .get_total_circulation()
-            .trunc()
-            .to_u64()
-            .unwrap()
-            .separate_with_commas(), // NOTE: Emulating Python server here by returning a truncated amount. Will be inexact in the future.
+        // NOTE: Emulating Python server here by returning a truncated amount.
+        //       Will be inexact in the future.
+        circulation_formatted: (
+                webcash_economy.get_total_circulation() / 10_u128.pow(WEBCASH_DECIMALS)
+            ).separate_with_commas(),
         circulation: webcash_economy
-            .get_total_circulation()
-            .trunc()
-            .to_u64()
-            .unwrap(), // NOTE: Emulating Python server here by returning a truncated amount. Will be inexact in the future.
+            .get_total_circulation() / 10_u128.pow(WEBCASH_DECIMALS),
         difficulty_target_bits: webcash_economy.get_difficulty_target_bits(),
-        ratio: webcash_economy.get_ratio().to_f64().unwrap(),
-        mining_amount: webcash_economy.get_mining_amount().to_string(),
-        mining_subsidy_amount: webcash_economy.get_subsidy_amount().to_string(),
+        ratio: webcash_economy.get_ratio(),
+        mining_amount: webcash_economy.get_mining_amount(),
+        mining_subsidy_amount: webcash_economy.get_subsidy_amount(),
         epoch: webcash_economy.get_epoch(),
         mining_reports: webcash_economy.get_mining_reports(),
     })
@@ -239,8 +229,8 @@ struct MiningReportResponse {
 
 #[derive(Deserialize)]
 struct PreimageRequest {
-    webcash: Vec<String>,
-    subsidy: Vec<String>,
+    webcash: Vec<SecretWebcash>,
+    subsidy: Vec<SecretWebcash>,
     #[serde(rename = "nonce")]
     _nonce: u64,
     timestamp: serde_json::Number,
@@ -248,8 +238,8 @@ struct PreimageRequest {
     legalese: LegaleseRequest,
 }
 
-const MAX_MINING_OUTPUT_SUBSIDY_TOKENS: usize = 100;
 const MAX_MINING_OUTPUT_TOKENS: usize = 100;
+const MAX_MINING_OUTPUT_SUBSIDY_TOKENS: usize = 100;
 
 #[cfg(not(tarpaulin_include))]
 #[must_use]
@@ -356,22 +346,31 @@ async fn mining_report(
     }
 
     // TODO: Check that subsidy token(s) is a subset of webcash tokens. JSON: {"webcash": ["e95000:secret:<hex>", "e5000:secret:<hex>"], "subsidy": ["e5000:secret:<hex>"], "nonce": 530201, "timestamp": 1651929787.514265, "difficulty": 20, "legalese": {"terms": true}}
-    let webcash_tokens = match webcash::parse_webcash_tokens(
-        &preimage.webcash,
-        &webcash::WebcashTokenKind::Secret,
-        MAX_MINING_OUTPUT_TOKENS,
-    ) {
-        Ok(webcash_tokens) => webcash_tokens,
-        Err(_) => {
-            return json_mining_report_response(
-                JSON_STATUS_ERROR,
-                "Could not parse webcash tokens.",
-                difficulty_target_bits,
-            );
-        }
-    };
+    let webcash_tokens = preimage.webcash;
+    if webcash_tokens.contains_duplicates() {
+        return json_mining_report_response(
+            JSON_STATUS_ERROR,
+            "Duplicate webcash in mining report.",
+            difficulty_target_bits,
+        );
+    }
+    if MAX_MINING_OUTPUT_TOKENS < webcash_tokens.len() {
+        return json_mining_report_response(
+            JSON_STATUS_ERROR,
+            "Number of webcash in mining report exceeds maximum limit.",
+            difficulty_target_bits,
+        );
+    }
 
-    let mining_amount = webcash::sum(&webcash_tokens);
+    let mining_amount = webcash_tokens.total_value();
+    if mining_amount.is_none() {
+        return json_mining_report_response(
+            JSON_STATUS_ERROR,
+            "Missing webcash in mining report.",
+            difficulty_target_bits,
+        );
+    }
+    let mining_amount = mining_amount.unwrap();
     if mining_amount != webcash_economy.get_mining_amount() {
         return json_mining_report_response(
             JSON_STATUS_ERROR,
@@ -381,22 +380,31 @@ async fn mining_report(
     }
 
     // TODO: Claim and store server operator's tokens.
-    let subsidy_tokens = match webcash::parse_webcash_tokens(
-        &preimage.subsidy,
-        &webcash::WebcashTokenKind::Secret,
-        MAX_MINING_OUTPUT_SUBSIDY_TOKENS,
-    ) {
-        Ok(webcash_tokens) => webcash_tokens,
-        Err(_) => {
-            return json_mining_report_response(
-                JSON_STATUS_ERROR,
-                "Could not parse subsidy tokens.",
-                difficulty_target_bits,
-            );
-        }
-    };
+    let subsidy_tokens = preimage.subsidy;
+    if subsidy_tokens.contains_duplicates() {
+        return json_mining_report_response(
+            JSON_STATUS_ERROR,
+            "Duplicate webcash in mining report.",
+            difficulty_target_bits,
+        );
+    }
+    if MAX_MINING_OUTPUT_SUBSIDY_TOKENS < subsidy_tokens.len() {
+        return json_mining_report_response(
+            JSON_STATUS_ERROR,
+            "Number of subsidy webcash in mining report exceeds maximum limit.",
+            difficulty_target_bits,
+        );
+    }
 
-    let subsidy_amount = webcash::sum(&subsidy_tokens);
+    let subsidy_amount = subsidy_tokens.total_value();
+    if subsidy_amount.is_none() {
+        return json_mining_report_response(
+            JSON_STATUS_ERROR,
+            "Missing subsidy in mining report.",
+            difficulty_target_bits,
+        );
+    }
+    let subsidy_amount = subsidy_amount.unwrap();
     if subsidy_amount != webcash_economy.get_subsidy_amount() {
         return json_mining_report_response(
             JSON_STATUS_ERROR,
@@ -425,7 +433,7 @@ async fn mining_report(
 #[derive(Serialize)]
 struct HealthCheckSpentResponse {
     spent: Option<bool>,
-    amount: Option<String>,
+    amount: Option<Amount>,
 }
 
 #[derive(Serialize)]
@@ -458,34 +466,24 @@ const MAX_HEALTH_CHECK_TOKENS: usize = 100;
 #[allow(clippy::unused_async)]
 async fn health_check(
     data: web::Data<WebcashApplicationState>,
-    health_check_request: web::Json<Vec<String>>,
+    health_check_request: web::Json<Vec<PublicWebcash>>,
 ) -> impl actix_web::Responder {
-    let webcash_tokens = match webcash::parse_webcash_tokens(
-        &health_check_request,
-        &webcash::WebcashTokenKind::Public,
-        MAX_HEALTH_CHECK_TOKENS,
-    ) {
-        Ok(webcash_tokens) => webcash_tokens,
-        Err(_) => {
-            return json_health_check_response(
-                JSON_STATUS_ERROR,
-                "Invalid token(s).",
-                std::collections::HashMap::<String, HealthCheckSpentResponse>::default(),
-            )
-        }
-    };
-    assert!(!webcash_tokens.is_empty());
-    assert!(webcash_tokens.len() == health_check_request.len());
-
+    if MAX_HEALTH_CHECK_TOKENS < health_check_request.len() {
+        return json_health_check_response(
+            JSON_STATUS_ERROR,
+            "Requested number of public webcash to check exceeds maximum limit.",
+            std::collections::HashMap::default(),
+        )
+    }
     let webcash_economy = &mut data.webcash_economy.lock().unwrap();
     let mut results = std::collections::HashMap::<String, HealthCheckSpentResponse>::default();
     // TODO: Move this to separate method in WebcashEconomy. Remove public access for get_using_public_token.
-    for public_webcash_token in &webcash_tokens {
+    for public_webcash_token in health_check_request.iter() {
         let mut spent: Option<bool> = None;
-        let mut amount: Option<String> = None;
+        let mut amount: Option<Amount> = None;
         if let Some(amount_state) = webcash_economy.get_using_public_token(public_webcash_token) {
             spent = Some(amount_state.spent);
-            amount = Some(amount_state.amount.to_string());
+            amount = Some(amount_state.amount);
         }
         results.insert(
             public_webcash_token.to_string(),
@@ -498,7 +496,7 @@ async fn health_check(
 }
 
 struct WebcashApplicationState {
-    webcash_economy: std::sync::Mutex<webcash::WebcashEconomy>,
+    webcash_economy: std::sync::Mutex<WebcashEconomy>,
 }
 
 #[actix_web::main]
@@ -513,7 +511,7 @@ async fn main() -> std::io::Result<()> {
     info!("Starting server instance at http://{SERVER_BIND_ADDRESS}:{SERVER_BIND_PORT}/");
 
     let persist_to_disk = true;
-    let webcash_economy = webcash::WebcashEconomy::new(persist_to_disk);
+    let webcash_economy = WebcashEconomy::new(persist_to_disk);
     info!(
         "The economy contains {} unspent webcash (in {} tokens) at startup.",
         webcash_economy.get_total_unspent().separate_with_commas(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ const WEBCASH_KIND_IDENTIFIER_PUBLIC: &str = "public";
 const WEBCASH_ECONOMY_JSON_FILE: &str = "webcashd.json";
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
 pub struct Amount {
     pub value: u64,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,313 +6,348 @@
 use thousands::Separable;
 #[macro_use]
 extern crate log;
-use rust_decimal::prelude::*;
+use primitive_types::H256;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 const OPTIONAL_AMOUNT_PREFIX: &str = "e";
-const MAX_WEBCASH: i64 = 210_000_000_000;
-const WEBCASH_DECIMALS: u32 = 8;
-
-const MINING_AMOUNT_IN_FIRST_EPOCH: i64 = 200_000;
-const MINING_REPORTS_PER_EPOCH: u32 = 525_000;
-const MINING_SOLUTION_MAX_AGE_IN_SECONDS: u64 = 15 * 30;
-const MINING_SUBSIDY_FRACTION: &str = "0.05";
-
-const WEBCASH_TOKEN_KIND_IDENTIFIER_PUBLIC: &str = "public";
-const WEBCASH_TOKEN_KIND_IDENTIFIER_SECRET: &str = "secret";
-
 const HEX_STRING_LENGTH: usize = 64;
+// It is a bit unfortunate, but the total issuance of webcash slightly exceeds
+// the representable range of a 64-bit integer.  We still use u64 to represent
+// amounts as no user transaction will ever have to exceed the implied limit of
+// 2^64 webcash per output.  But this does mean that calculations of the total
+// issuance need to use u128 instead of webcash amounts.
+pub const MAX_WEBCASH: u64 = 92_233_720_368__5477_5807; // 2^64 - 1
+pub const TOTAL_ISSUANCE: u128 = 209_999_999_999__9265_0000;
+pub const WEBCASH_DECIMALS: u32 = 8;
+
+const MINING_AMOUNT_IN_FIRST_EPOCH: u64 = 200_000__0000_0000;
+const MINING_REPORTS_PER_EPOCH: usize = 525_000;
+const MINING_SOLUTION_MAX_AGE_IN_SECONDS: u64 = 2 * 60 * 60; // 2 hrs
+const MINING_SUBSIDY_FRAC_NUMERATOR: u64 = 1; // 1/20 = 0.05
+const MINING_SUBSIDY_FRAC_DENOMINATOR: u64 = 20;
+
+const WEBCASH_KIND_IDENTIFIER_SECRET: &str = "secret";
+const WEBCASH_KIND_IDENTIFIER_PUBLIC: &str = "public";
 
 const WEBCASH_ECONOMY_JSON_FILE: &str = "webcashd.json";
 
-#[derive(PartialEq, Clone, Debug)]
-pub enum WebcashTokenKind {
-    Public,
-    Secret,
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, PartialOrd, Serialize)]
+pub struct Amount {
+    pub value: u64,
 }
 
-#[derive(Clone)]
-pub struct WebcashToken {
-    pub amount: Decimal,
-    pub token_kind: WebcashTokenKind,
-    pub hex_string: String,
+impl std::ops::Add for Amount {
+    type Output = Self;
+    fn add(self, other: Self) -> Self::Output {
+        Amount::from(self.value + other.value)
+    }
 }
 
-impl WebcashToken {
+impl std::ops::Sub for Amount {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self::Output {
+        Amount::from(self.value - other.value)
+    }
+}
+
+impl std::iter::Sum for Amount {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = Self>,
+    {
+        Self::from(iter.map(|wc| wc.value).sum::<u64>())
+    }
+}
+
+impl std::convert::From<u64> for Amount {
+    fn from(n: u64) -> Self {
+        assert!(1 <= n);
+        assert!(n <= MAX_WEBCASH);
+        Amount { value: n }
+    }
+}
+
+impl std::fmt::Display for Amount {
     #[must_use]
-    fn to_public(&self) -> WebcashToken {
-        assert!(self.token_kind == WebcashTokenKind::Secret);
-        WebcashToken {
-            amount: self.amount,
-            token_kind: WebcashTokenKind::Public,
-            hex_string: secret_to_public(&self.hex_string),
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let divmod = (
+            self.value / 10_u64.pow(WEBCASH_DECIMALS),
+            self.value % 10_u64.pow(WEBCASH_DECIMALS),
+        );
+        if divmod.1 == 0 {
+            // Integer number of webcash, so don't use a decimal point.
+            write!(fmt, "{}", divmod.0)
+        } else {
+            // Add leading zeros
+            // Note: This should be using the WEBCASH_DECIMALS constant here,
+            //       but I'm not sure how to convert that to a string such that
+            //       the format!() macro can use it.
+            let mut frac = format!("{:08}", divmod.1);
+            // Remove trailing zeros
+            while let Some(c) = frac.pop() {
+                if c != '0' {
+                    frac.push(c);
+                    break;
+                }
+            }
+            // Combine inteer and fractional parts
+            write!(fmt, "{}.{}", divmod.0, frac)
         }
     }
 }
 
-#[must_use]
-fn contains_duplicates(webcash_tokens: &Vec<WebcashToken>) -> bool {
-    let mut unique_hex_strings: Vec<String> = webcash_tokens
-        .iter()
-        .map(|wc| wc.hex_string.to_string())
-        .collect();
-    unique_hex_strings.sort();
-    unique_hex_strings.dedup();
-    unique_hex_strings.len() != webcash_tokens.len()
-}
-
-#[must_use]
-pub fn sum(tokens: &[WebcashToken]) -> Decimal {
-    tokens.iter().map(|wc| wc.amount).sum()
-}
-
-#[must_use]
-fn are_syntactically_valid_tokens(
-    tokens: &Vec<WebcashToken>,
-    allowed_token_type: &WebcashTokenKind,
-) -> bool {
-    if !tokens.iter().all(|wc| wc.token_kind == *allowed_token_type) {
-        return false;
-    }
-    if !tokens.iter().all(is_webcash_token_object) {
-        return false;
-    }
-    if contains_duplicates(tokens) {
-        return false;
-    }
-    let total_amount = sum(tokens);
-    if !is_webcash_amount(total_amount) {
-        return false;
-    }
-    true
-}
-
-pub fn parse_webcash_tokens(
-    webcash_strings: &[String],
-    allowed_token_type: &WebcashTokenKind,
-    max_tokens: usize,
-) -> Result<Vec<WebcashToken>, String> {
-    if webcash_strings.is_empty() {
-        return Err(String::from("Zero tokens."));
-    }
-    if webcash_strings.len() > max_tokens {
-        return Err(String::from("Too many tokens."));
-    }
-    let mut webcash_tokens = Vec::<WebcashToken>::default();
-    for webcash_token_string in webcash_strings {
-        let token = match webcash_token_string.parse::<WebcashToken>() {
-            Ok(token) => token,
-            Err(_) => return Err(String::from("Invalid token.")),
+impl std::str::FromStr for Amount {
+    type Err = Box<dyn std::error::Error>;
+    #[must_use]
+    fn from_str(s: &str) -> Result<Amount, Self::Err> {
+        // Remove optional amount prefix
+        let s =
+        if !OPTIONAL_AMOUNT_PREFIX.is_empty() && s.starts_with(OPTIONAL_AMOUNT_PREFIX) {
+            &s[OPTIONAL_AMOUNT_PREFIX.len()..]
+        } else {
+            s
         };
-        assert!(is_webcash_token(webcash_token_string));
-        assert!(is_webcash_token(&token.to_string()));
-        webcash_tokens.push(token);
+        // Make sure we're dealing with an integer or fraction only
+        if !s.chars().all(|ch| ('0'..='9').contains(&ch) || ch == '.') {
+            return Err("amount string contains unexpected characters")?;
+        }
+        // Make sure there's no unnecessary leading zeros
+        if s.starts_with('0') && !s.starts_with("0.") {
+            return Err("unnecessary leading zeros are disallowed")?;
+        }
+        if s.contains('.') {
+            // Validate integer part
+            let parts: Vec<&str> = s.split('.').collect();
+            if parts.len() != 2 {
+                return Err("amount string contains unexpected characters")?;
+            }
+            let int_part = parts[0].parse::<u64>()?.checked_mul(10_u64.pow(WEBCASH_DECIMALS));
+            if int_part.is_none() {
+                return Err("overflow")?;
+            }
+            // Validate fractional part
+            if WEBCASH_DECIMALS < (parts[1].len() as u32) {
+                return Err("too many fractional digits")?;
+            }
+            let frac_part = parts[1].parse::<u64>()?.checked_mul(10_u64.pow(WEBCASH_DECIMALS - (parts[1].len() as u32)));
+            if frac_part.is_none() {
+                return Err("overflow")?;
+            }
+            // Combine both parts
+            let n = int_part.unwrap().checked_add(frac_part.unwrap());
+            if n.is_none() {
+                return Err("overflow")?;
+            }
+            let n = n.unwrap();
+            if n < 1 {
+                return Err("underflow")?;
+            }
+            if n > MAX_WEBCASH {
+                return Err("overflow")?;
+            }
+            Ok(Amount::from(n))
+        } else {
+            // Parse and scale string as integer part only
+            let n = s.parse::<u64>()?.checked_mul(10_u64.pow(WEBCASH_DECIMALS));
+            if n.is_none() {
+                return Err("overflow")?;
+            }
+            let n = n.unwrap();
+            if n < 1 {
+                return Err("underflow")?;
+            }
+            if n > MAX_WEBCASH {
+                return Err("overflow")?;
+            }
+            Ok(Amount::from(n))
+        }
     }
-    assert!(webcash_strings.len() == webcash_tokens.len());
-    if !are_syntactically_valid_tokens(&webcash_tokens, allowed_token_type) {
-        return Err(String::from("Invalid tokens."));
-    }
-    Ok(webcash_tokens)
 }
 
-impl std::fmt::Display for WebcashTokenKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", webcash_token_kind_to_string(self))
+#[derive(PartialEq)]
+pub enum WebcashKind {
+    Secret,
+    Public,
+}
+
+impl std::fmt::Display for WebcashKind {
+    #[must_use]
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            WebcashKind::Secret => write!(fmt, "{}", WEBCASH_KIND_IDENTIFIER_SECRET),
+            WebcashKind::Public => write!(fmt, "{}", WEBCASH_KIND_IDENTIFIER_PUBLIC),
+        }
     }
 }
 
-impl std::fmt::Display for WebcashToken {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        assert!(is_webcash_token_object(self));
-        write!(f, "{}", webcash_token_to_string(self))
+impl std::str::FromStr for WebcashKind {
+    type Err = Box<dyn std::error::Error>;
+    #[must_use]
+    fn from_str(s: &str) -> Result<WebcashKind, Self::Err> {
+        match s {
+            WEBCASH_KIND_IDENTIFIER_SECRET => Ok(WebcashKind::Secret),
+            WEBCASH_KIND_IDENTIFIER_PUBLIC => Ok(WebcashKind::Public),
+            _ => Err("unexpected webcash claim code type")?
+        }
     }
 }
 
-impl std::str::FromStr for WebcashToken {
-    type Err = String;
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct SecretWebcash {
+    pub secret: String,
+    pub amount: Amount,
+}
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        parse_webcash_token(s).ok_or(format!("'{s}' is not a valid value for WebcashToken"))
+impl std::fmt::Display for SecretWebcash {
+    #[must_use]
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(fmt, "{}{}:{}:{}",
+            OPTIONAL_AMOUNT_PREFIX,
+            self.amount,
+            WebcashKind::Secret,
+            self.secret,
+        )?;
+        Ok(())
     }
 }
 
-#[must_use]
-fn is_webcash_amount(amount: Decimal) -> bool {
-    let webcash_min_amount = Decimal::new(1, WEBCASH_DECIMALS);
-    let webcash_max_amount = Decimal::new(MAX_WEBCASH, 0);
-    if amount < webcash_min_amount {
-        return false;
+impl std::str::FromStr for SecretWebcash {
+    type Err = Box<dyn std::error::Error>;
+    #[must_use]
+    fn from_str(s: &str) -> Result<SecretWebcash, Self::Err> {
+        // Split the input into amount, kind, secret
+        let parts: Vec<&str> = s.split(":").collect();
+        if parts.len() < 3 {
+            return Err("insufficient number of segments in webcash code")?;
+        }
+        // Parse and validate each component
+        let amount: Amount = parts[0].parse()?;
+        let kind: WebcashKind = parts[1].parse()?;
+        let secret: String = parts[2..].join(":");
+        // Only accept SecretWebcash
+        if kind != WebcashKind::Secret {
+            return Err("expected secret webcash code")?;
+        }
+        Ok(SecretWebcash { secret, amount })
     }
-    if amount > webcash_max_amount {
-        return false;
-    }
-    let valid_precision = ((amount * Decimal::new(i64::pow(10, WEBCASH_DECIMALS), 0))
-        % Decimal::new(1, 0))
-        == Decimal::new(0, 0);
-    if !valid_precision {
-        return false;
-    }
-    true
 }
 
-#[must_use]
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct PublicWebcash {
+    pub hash: H256,
+    pub amount: Option<Amount>,
+}
+
+impl SecretWebcash {
+    #[must_use]
+    fn to_public(&self) -> PublicWebcash {
+        PublicWebcash {
+            hash: H256::from_slice(&Sha256::digest(&self.secret)),
+            amount: Some(self.amount),
+        }
+    }
+}
+
+impl std::fmt::Display for PublicWebcash {
+    #[must_use]
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(fmt, "{}{}:{}:{:x}",
+            OPTIONAL_AMOUNT_PREFIX,
+            self.amount.map_or("0".to_owned(), |n| n.to_string()),
+            WebcashKind::Public,
+            self.hash,
+        )?;
+        Ok(())
+    }
+}
+
 fn is_webcash_hex_string(hex: &str) -> bool {
     hex.len() == HEX_STRING_LENGTH
         && hex
             .chars()
-            .all(|ch| ('0'..='9').contains(&ch) || ('a'..='f').contains(&ch))
+            .all(|ch| ('0'..='9').contains(&ch) || ('a'..='f').contains(&ch) || ('A'..='F').contains(&ch))
 }
 
-#[must_use]
-fn parse_webcash_amount(amount_str: &str) -> Option<Decimal> {
-    let amount_str =
-        if !OPTIONAL_AMOUNT_PREFIX.is_empty() && amount_str.starts_with(OPTIONAL_AMOUNT_PREFIX) {
-            &amount_str[OPTIONAL_AMOUNT_PREFIX.len()..]
-        } else {
-            amount_str
-        };
-    if !amount_str
-        .chars()
-        .all(|ch| ('0'..='9').contains(&ch) || ch == '.')
-    {
-        return None;
-    }
-    if amount_str.starts_with('0') && !amount_str.starts_with("0.") {
-        return None;
-    }
-    if amount_str.contains('.') {
-        let amount_parts: Vec<&str> = amount_str.split('.').collect();
-        if amount_parts.len() != 2 {
-            return None;
-        }
-        let integer_part = amount_parts[0];
-        if integer_part.is_empty() || integer_part.len() > MAX_WEBCASH.to_string().len() {
-            return None;
-        }
-        let fractional_part = amount_parts[1];
-        if fractional_part.is_empty() || fractional_part.len() > WEBCASH_DECIMALS as usize {
-            return None;
-        }
-    } else if amount_str.is_empty() || amount_str.len() > MAX_WEBCASH.to_string().len() {
-        return None;
-    }
-    let amount = Decimal::from_str_exact(amount_str).ok()?;
-    assert!(!amount.is_sign_negative());
-    assert!(amount.to_string().len() <= amount_str.len());
-    if !is_webcash_amount(amount) {
-        return None;
-    }
-    Some(amount)
-}
-
-#[must_use]
-fn parse_webcash_hex_string(hex: &str) -> Option<String> {
-    if !is_webcash_hex_string(hex) {
-        return None;
-    }
-    Some(hex.to_string())
-}
-
-#[must_use]
-fn parse_webcash_token_kind(webcash_token_kind_str: &str) -> Option<WebcashTokenKind> {
-    match webcash_token_kind_str {
-        WEBCASH_TOKEN_KIND_IDENTIFIER_PUBLIC => Some(WebcashTokenKind::Public),
-        WEBCASH_TOKEN_KIND_IDENTIFIER_SECRET => Some(WebcashTokenKind::Secret),
-        _ => None,
-    }
-}
-
-#[must_use]
-fn webcash_token_kind_to_string(token_kind: &WebcashTokenKind) -> String {
-    match token_kind {
-        WebcashTokenKind::Public => String::from(WEBCASH_TOKEN_KIND_IDENTIFIER_PUBLIC),
-        WebcashTokenKind::Secret => String::from(WEBCASH_TOKEN_KIND_IDENTIFIER_SECRET),
-    }
-}
-
-#[must_use]
-fn is_webcash_token_kind_string(webcash_token_kind_str: &str) -> bool {
-    webcash_token_kind_str == WEBCASH_TOKEN_KIND_IDENTIFIER_PUBLIC
-        || webcash_token_kind_str == WEBCASH_TOKEN_KIND_IDENTIFIER_SECRET
-}
-
-impl WebcashToken {
+impl std::str::FromStr for PublicWebcash {
+    type Err = Box<dyn std::error::Error>;
     #[must_use]
-    fn new(amount: Decimal, token_kind: WebcashTokenKind, hex_string: &str) -> WebcashToken {
-        assert!(!amount.is_sign_negative());
-        assert!(is_webcash_amount(amount) && is_webcash_amount(amount.normalize()));
-        assert!(is_webcash_token_kind_string(&token_kind.to_string()));
-        assert!(is_webcash_hex_string(hex_string));
-        let webcash = WebcashToken {
-            amount: amount.normalize(),
-            token_kind,
-            hex_string: hex_string.to_string(),
-        };
-        assert!(is_webcash_token_object(&webcash));
-        assert_eq!(webcash.hex_string.len(), HEX_STRING_LENGTH);
-        assert_eq!(webcash.hex_string, webcash.hex_string.to_lowercase());
-        webcash
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Split the input into amount, kind, hash
+        let parts: Vec<&str> = s.split(":").collect();
+        if parts.len() != 3 {
+            return Err("unexpected number of segments in webcash code")?;
+        }
+        // Parse and validate each component
+        let amount: Option<Amount> = parts[0].parse().ok();
+        let kind: WebcashKind = parts[1].parse()?;
+        // Note: The primitive-types crate does full validation of input for
+        //       hash values, ensuring that it is a 64-character hex-encoded
+        //       string.  To protect against regressions, we should check that
+        //       other strings are rejected in our own module's unit tests.
+        if !is_webcash_hex_string(parts[2]) {
+            return Err("public webcash code must be 64-character hex string")?;
+        }
+        let hash: H256 = parts[2].parse()?;
+        // Only accept PublicWebcash
+        if kind != WebcashKind::Public {
+            return Err("expected public webcash code")?;
+        }
+        Ok(PublicWebcash { hash, amount })
     }
 }
 
-#[must_use]
-fn is_webcash_token_object(token: &WebcashToken) -> bool {
-    is_webcash_amount(token.amount)
-        && is_webcash_token_kind_string(&token.token_kind.to_string())
-        && is_webcash_hex_string(&token.hex_string)
+pub trait CheckForDuplicates {
+    fn contains_duplicates(&self) -> bool;
 }
 
-#[must_use]
-fn is_webcash_token(webcash_token_str: &str) -> bool {
-    let token = match webcash_token_str.parse::<WebcashToken>() {
-        Ok(token) => token,
-        Err(_) => return false,
-    };
-    assert!(is_webcash_token_object(&token));
-    true
-}
-
-#[must_use]
-fn parse_webcash_token(webcash_token_str: &str) -> Option<WebcashToken> {
-    let token_parts: Vec<&str> = webcash_token_str.split(':').collect();
-    if token_parts.len() != 3 {
-        return None;
+impl CheckForDuplicates for Vec<SecretWebcash> {
+    #[must_use]
+    fn contains_duplicates(&self) -> bool {
+        let mut unique_hex_strings: Vec<String> =
+            self.iter().map(|wc| wc.secret.clone()).collect(); // FIXME: can we remove this .clone()?
+        unique_hex_strings.sort();
+        unique_hex_strings.dedup();
+        unique_hex_strings.len() != self.len()
     }
-
-    let amount = parse_webcash_amount(token_parts[0])?;
-    let token_kind = parse_webcash_token_kind(token_parts[1])?;
-    let hex_string = parse_webcash_hex_string(token_parts[2])?;
-
-    let webcash = WebcashToken::new(amount, token_kind, &hex_string);
-    Some(webcash)
 }
 
-#[must_use]
-fn webcash_token_to_string(token: &WebcashToken) -> String {
-    assert!(is_webcash_token_object(token));
-    format!(
-        "e{}:{}:{}",
-        token.amount.normalize(),
-        token.token_kind,
-        token.hex_string
-    )
+impl CheckForDuplicates for Vec<PublicWebcash> {
+    #[must_use]
+    fn contains_duplicates(&self) -> bool {
+        let mut unique_hashes: Vec<H256> =
+            self.iter().map(|wc| wc.hash).collect();
+        unique_hashes.sort();
+        unique_hashes.dedup();
+        unique_hashes.len() != self.len()
+    }
 }
 
-#[must_use]
-fn secret_to_public(secret_value: &str) -> String {
-    assert_eq!(secret_value.len(), HEX_STRING_LENGTH);
-    assert!(is_webcash_hex_string(secret_value));
-    let hash = Sha256::digest(secret_value);
-    let hex_hash = format!("{hash:x}");
-    assert_eq!(hex_hash.len(), HEX_STRING_LENGTH);
-    assert!(is_webcash_hex_string(&hex_hash));
-    hex_hash
+pub trait SumAmounts {
+    fn total_value(&self) -> Option<Amount>;
+}
+
+impl SumAmounts for Vec<SecretWebcash> {
+    #[must_use]
+    fn total_value(&self) -> Option<Amount> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(self.iter().map(|wc| wc.amount).sum())
+        }
+    }
+}
+
+impl SumAmounts for Vec<PublicWebcash> {
+    #[must_use]
+    fn total_value(&self) -> Option<Amount> {
+        self.iter().map(|wc| wc.amount).sum()
+    }
 }
 
 #[derive(Deserialize, Serialize)]
-pub struct AmountState {
-    pub amount: Decimal,
+pub struct Output {
+    pub amount: Amount,
     pub spent: bool,
 }
 
@@ -323,38 +358,38 @@ fn serde_default_literals_workaround_default_true() -> bool {
 
 #[derive(Deserialize, Serialize)]
 pub struct WebcashEconomy {
-    public_hash_to_amount_state: std::collections::HashMap<String, AmountState>,
+    public_hash_to_amount_state: std::collections::HashMap<H256, Output>,
     #[serde(skip, default = "serde_default_literals_workaround_default_true")]
     persist_to_disk: bool,
 }
 
-const DUMMY_VALUE_MINING_REPORTS: u32 = 1_000_000;
+const DUMMY_VALUE_MINING_REPORTS: usize = 1_000_000;
 const DUMMY_VALUE_DIFFICULTY_TARGET_BITS: u8 = 20;
 const DUMMY_VALUE_RATIO: f32 = 1.0001;
 
 impl WebcashEconomy {
     #[must_use]
-    pub fn get_epoch(&self) -> u32 {
+    pub fn get_epoch(&self) -> usize {
         epoch(self.get_mining_reports())
     }
 
     #[must_use]
-    pub fn get_total_circulation(&self) -> Decimal {
+    pub fn get_total_circulation(&self) -> u128 {
         total_circulation(self.get_mining_reports())
     }
 
     #[must_use]
-    pub fn get_mining_amount(&self) -> Decimal {
-        mining_amount_for_mining_report(self.get_mining_reports())
+    pub fn get_mining_amount(&self) -> Amount {
+        Amount::from(mining_amount_for_mining_report(self.get_mining_reports()))
     }
 
     #[must_use]
-    pub fn get_subsidy_amount(&self) -> Decimal {
-        mining_subsidy_amount_for_mining_report(self.get_mining_reports())
+    pub fn get_subsidy_amount(&self) -> Amount {
+        Amount::from(mining_subsidy_amount_for_mining_report(self.get_mining_reports()))
     }
 
     #[must_use]
-    pub fn get_mining_reports(&self) -> u32 {
+    pub fn get_mining_reports(&self) -> usize {
         DUMMY_VALUE_MINING_REPORTS
     }
 
@@ -393,15 +428,14 @@ impl WebcashEconomy {
     }
 
     #[must_use]
-    pub fn get_total_unspent(&self) -> Decimal {
+    pub fn get_total_unspent(&self) -> Amount {
         let now = std::time::Instant::now();
         let total_unspent = self
             .public_hash_to_amount_state
             .values()
             .filter(|amount_state| !amount_state.spent)
             .map(|amount_state| amount_state.amount)
-            .sum::<Decimal>()
-            .normalize();
+            .sum::<Amount>();
         trace!(
             "Calculating total unspent webcash took {} ms.",
             now.elapsed().as_millis()
@@ -418,30 +452,25 @@ impl WebcashEconomy {
             .filter(|amount_state| !amount_state.spent)
             .count();
         trace!(
-            "Calculating number of unspent tookens took {} ms.",
+            "Calculating number of unspent tokens took {} ms.",
             now.elapsed().as_millis()
         );
         number_of_unspent_tokens
     }
 
     #[must_use]
-    pub fn get_using_public_token(&self, public_token: &WebcashToken) -> Option<&AmountState> {
-        assert!(public_token.token_kind == WebcashTokenKind::Public);
+    pub fn get_using_public_token(&self, public_token: &PublicWebcash) -> Option<&Output> {
         self.public_hash_to_amount_state
-            .get(&public_token.hex_string)
+            .get(&public_token.hash)
     }
 
     #[must_use]
-    fn get_using_secret_token(&self, secret_token: &WebcashToken) -> Option<&AmountState> {
-        assert!(secret_token.token_kind == WebcashTokenKind::Secret);
+    fn get_using_secret_token(&self, secret_token: &SecretWebcash) -> Option<&Output> {
         self.get_using_public_token(&secret_token.to_public())
     }
 
     #[must_use]
-    fn is_unspent_secret_token_with_correct_amount(&self, secret_token: &WebcashToken) -> bool {
-        if secret_token.token_kind != WebcashTokenKind::Secret {
-            return false;
-        }
+    fn is_unspent_secret_token_with_correct_amount(&self, secret_token: &SecretWebcash) -> bool {
         let amount_state = match self.get_using_secret_token(secret_token) {
             Some(amount_state) => amount_state,
             None => return false,
@@ -456,10 +485,7 @@ impl WebcashEconomy {
     }
 
     #[must_use]
-    fn are_unspent_valid_input_tokens(&self, secret_input_tokens: &Vec<WebcashToken>) -> bool {
-        if !are_syntactically_valid_tokens(secret_input_tokens, &WebcashTokenKind::Secret) {
-            return false;
-        }
+    fn are_unspent_valid_input_tokens(&self, secret_input_tokens: &Vec<SecretWebcash>) -> bool {
         if !secret_input_tokens
             .iter()
             .all(|wc| self.is_unspent_secret_token_with_correct_amount(wc))
@@ -470,21 +496,15 @@ impl WebcashEconomy {
     }
 
     #[must_use]
-    fn is_valid_output_token_with_non_taken_hash(&self, secret_token: &WebcashToken) -> bool {
-        if secret_token.token_kind != WebcashTokenKind::Secret {
-            return false;
-        }
+    fn is_valid_output_token_with_non_taken_hash(&self, secret_token: &SecretWebcash) -> bool {
         self.get_using_secret_token(secret_token).is_none()
     }
 
     #[must_use]
     fn are_valid_output_tokens_with_non_taken_hashes(
         &self,
-        secret_output_tokens: &Vec<WebcashToken>,
+        secret_output_tokens: &Vec<SecretWebcash>,
     ) -> bool {
-        if !are_syntactically_valid_tokens(secret_output_tokens, &WebcashTokenKind::Secret) {
-            return false;
-        }
         if !secret_output_tokens
             .iter()
             .all(|wc| self.is_valid_output_token_with_non_taken_hash(wc))
@@ -505,16 +525,15 @@ impl WebcashEconomy {
         );
     }
 
-    fn create_token(&mut self, secret_webcash_token: &WebcashToken) {
-        assert_eq!(secret_webcash_token.token_kind, WebcashTokenKind::Secret);
+    fn create_token(&mut self, secret_webcash_token: &SecretWebcash) {
         let old_value = self.public_hash_to_amount_state.insert(
-            secret_webcash_token.to_public().hex_string,
-            AmountState {
+            secret_webcash_token.to_public().hash,
+            Output {
                 amount: secret_webcash_token.amount,
                 spent: false,
             },
         );
-        assert!(old_value.is_none());
+        assert!(old_value.is_none()); // FIXME: should check before insertion?
         debug!(
             "[diff: +] Token of amount {} created",
             secret_webcash_token.amount.separate_with_commas()
@@ -522,7 +541,7 @@ impl WebcashEconomy {
     }
 
     #[must_use]
-    pub fn create_tokens(&mut self, secret_outputs: &Vec<WebcashToken>) -> bool {
+    pub fn create_tokens(&mut self, secret_outputs: &Vec<SecretWebcash>) -> bool {
         let total_unspent_before = self.get_total_unspent();
         if !self.are_valid_output_tokens_with_non_taken_hashes(secret_outputs) {
             return false;
@@ -530,9 +549,9 @@ impl WebcashEconomy {
         for secret_output in secret_outputs {
             self.create_token(secret_output);
         }
-        assert_eq!(
-            self.get_total_unspent() - total_unspent_before,
-            sum(secret_outputs)
+        assert_eq!( // FIXME: Should be checked before?
+            Some(self.get_total_unspent() - total_unspent_before),
+            secret_outputs.total_value()
         );
         if self.persist_to_disk {
             self.sync_to_disk();
@@ -563,12 +582,11 @@ impl WebcashEconomy {
         trace!("Sync to disk took {} ms.", now.elapsed().as_millis());
     }
 
-    fn mark_as_spent(&mut self, secret_webcash_token: &WebcashToken) {
-        assert_eq!(secret_webcash_token.token_kind, WebcashTokenKind::Secret);
+    fn mark_as_spent(&mut self, secret_webcash_token: &SecretWebcash) {
         assert!(self.is_unspent_secret_token_with_correct_amount(secret_webcash_token));
-        let amount_state: &mut AmountState = self
+        let amount_state: &mut Output = self
             .public_hash_to_amount_state
-            .get_mut(&secret_webcash_token.to_public().hex_string)
+            .get_mut(&secret_webcash_token.to_public().hash)
             .unwrap();
         assert_eq!(amount_state.amount, secret_webcash_token.amount);
         assert!(!amount_state.spent);
@@ -582,8 +600,8 @@ impl WebcashEconomy {
     #[must_use]
     pub fn replace_tokens(
         &mut self,
-        secret_inputs: &Vec<WebcashToken>,
-        secret_outputs: &Vec<WebcashToken>,
+        secret_inputs: &Vec<SecretWebcash>,
+        secret_outputs: &Vec<SecretWebcash>,
     ) -> bool {
         let total_unspent_before = self.get_total_unspent();
         if !self.are_unspent_valid_input_tokens(secret_inputs) {
@@ -592,10 +610,10 @@ impl WebcashEconomy {
         if !self.are_valid_output_tokens_with_non_taken_hashes(secret_outputs) {
             return false;
         }
-        if contains_duplicates(&[secret_inputs.as_slice(), secret_outputs.as_slice()].concat()) {
+        if [secret_inputs.as_slice(), secret_outputs.as_slice()].concat().contains_duplicates() {
             return false;
         }
-        if sum(secret_inputs) != sum(secret_outputs) {
+        if secret_inputs.total_value() != secret_outputs.total_value() {
             return false;
         }
         for secret_input in secret_inputs {
@@ -616,55 +634,40 @@ impl WebcashEconomy {
 }
 
 // TODO: How to handle zero return value case (in the future when no mining reward))? Is not a valid webcash amount.
-fn mining_amount_per_mining_report_in_epoch(epoch: u32) -> Decimal {
-    if epoch >= 63 {
-        return Decimal::new(0, 0);
+fn mining_amount_per_mining_report_in_epoch(epoch: usize) -> u64 {
+    if epoch >= 64 {
+        0
+    } else {
+        MINING_AMOUNT_IN_FIRST_EPOCH >> epoch
     }
-    (Decimal::new(MINING_AMOUNT_IN_FIRST_EPOCH, 0) / Decimal::new(i64::pow(2, epoch), 0))
-        .round_dp(WEBCASH_DECIMALS)
-        .normalize()
 }
 
 // TODO: How to handle zero return value case (in the future when no mining reward))? Is not a valid webcash amount.
 #[must_use]
-fn mining_amount_for_mining_report(mining_report_number: u32) -> Decimal {
-    assert!(mining_report_number >= 1);
-    mining_amount_per_mining_report_in_epoch(epoch(mining_report_number))
+fn mining_amount_for_mining_report(num_mining_reports: usize) -> u64 {
+    mining_amount_per_mining_report_in_epoch(epoch(num_mining_reports))
 }
 
 // TODO: How to handle zero return value case? Is not a valid webcash amount.
 #[must_use]
-fn mining_subsidy_amount_for_mining_report(mining_report_number: u32) -> Decimal {
-    assert!(mining_report_number >= 1);
-    (mining_amount_for_mining_report(mining_report_number) * decimal(MINING_SUBSIDY_FRACTION))
-        .round_dp(WEBCASH_DECIMALS)
-        .normalize()
+fn mining_subsidy_amount_for_mining_report(num_mining_reports: usize) -> u64 {
+    mining_amount_per_mining_report_in_epoch(epoch(num_mining_reports)) * MINING_SUBSIDY_FRAC_NUMERATOR / MINING_SUBSIDY_FRAC_DENOMINATOR
 }
 
 #[must_use]
-fn epoch(mining_report_number: u32) -> u32 {
-    assert!(mining_report_number >= 1);
-    (mining_report_number - 1) / MINING_REPORTS_PER_EPOCH
+fn epoch(num_mining_reports: usize) -> usize {
+    num_mining_reports / MINING_REPORTS_PER_EPOCH
 }
 
 #[must_use]
-fn total_circulation(mining_report_number: u32) -> Decimal {
-    assert!(mining_report_number >= 1);
-    let mut total_circulation = Decimal::default();
-    let mut mining_reports_in_current_epoch = mining_report_number;
-    for past_epoch in 0..epoch(mining_report_number) {
-        total_circulation += mining_amount_per_mining_report_in_epoch(past_epoch)
-            * Decimal::new(i64::from(MINING_REPORTS_PER_EPOCH), 0);
+fn total_circulation(num_mining_reports: usize) -> u128 {
+    let mut total_circulation: u128 = 0;
+    let mut mining_reports_in_current_epoch = num_mining_reports;
+    for past_epoch in 0..epoch(num_mining_reports) {
+        total_circulation += (mining_amount_per_mining_report_in_epoch(past_epoch) * MINING_REPORTS_PER_EPOCH as u64) as u128;
         mining_reports_in_current_epoch -= MINING_REPORTS_PER_EPOCH;
     }
-    total_circulation += mining_amount_per_mining_report_in_epoch(epoch(mining_report_number))
-        * Decimal::new(i64::from(mining_reports_in_current_epoch), 0);
-    assert!(is_webcash_amount(total_circulation));
-    total_circulation
-}
-
-fn decimal(str: &str) -> Decimal {
-    Decimal::from_str_exact(str).unwrap()
+    total_circulation + (mining_amount_per_mining_report_in_epoch(epoch(num_mining_reports)) * mining_reports_in_current_epoch as u64) as u128
 }
 
 #[cfg(test)]
@@ -674,13 +677,27 @@ mod tests {
     #[test]
     fn test_secret_to_public() {
         assert_eq!(
-            secret_to_public("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"),
-            "d7914fe546b684688bb95f4f888a92dfc680603a75f23eb823658031fff766d9"
+            "e1:secret:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824".parse::<SecretWebcash>().unwrap().to_public().to_string(),
+            "e1:public:d7914fe546b684688bb95f4f888a92dfc680603a75f23eb823658031fff766d9"
         );
         assert_eq!(
-            secret_to_public("b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"),
-            "049da052634feb56ce6ec0bc648c672011edff1cb272b53113bbc90a8f00249c"
+            "e1:secret:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9".parse::<SecretWebcash>().unwrap().to_public().to_string(),
+            "e1:public:049da052634feb56ce6ec0bc648c672011edff1cb272b53113bbc90a8f00249c"
         );
+    }
+
+    fn parse_secret_webcash(v: &[String]) -> Vec<SecretWebcash> {
+        v.iter().map(|s| s.parse::<SecretWebcash>())
+                .filter(|r| r.is_ok())
+                .map(|r| r.unwrap())
+                .collect()
+    }
+
+    fn parse_public_webcash(v: &[String]) -> Vec<PublicWebcash> {
+        v.iter().map(|s| s.parse::<PublicWebcash>())
+                .filter(|r| r.is_ok())
+                .map(|r| r.unwrap())
+                .collect()
     }
 
     #[test]
@@ -691,14 +708,8 @@ mod tests {
             String::from("e1:secret:12345678901234567890123456789012345678901234567890123456789abcd3"),
             String::from("e1:secret:12345678901234567890123456789012345678901234567890123456789abcd4"),
         ];
-        assert!(
-            parse_webcash_tokens(&valid_secret_tokens, &WebcashTokenKind::Public, 100).is_err()
-        );
-        assert!(parse_webcash_tokens(&valid_secret_tokens, &WebcashTokenKind::Secret, 100).is_ok());
-        assert!(parse_webcash_tokens(&valid_secret_tokens, &WebcashTokenKind::Public, 4).is_err());
-        assert!(parse_webcash_tokens(&valid_secret_tokens, &WebcashTokenKind::Secret, 4).is_ok());
-        assert!(parse_webcash_tokens(&valid_secret_tokens, &WebcashTokenKind::Public, 3).is_err());
-        assert!(parse_webcash_tokens(&valid_secret_tokens, &WebcashTokenKind::Secret, 3).is_err());
+        assert_eq!(parse_secret_webcash(&valid_secret_tokens).len(), 4);
+        assert_eq!(parse_public_webcash(&valid_secret_tokens).len(), 0);
 
         let valid_public_tokens = vec![
             String::from("e0.00000001:public:12345678901234567890123456789012345678901234567890123456789abcd1"),
@@ -706,14 +717,8 @@ mod tests {
             String::from("e1:public:12345678901234567890123456789012345678901234567890123456789abcd3"),
             String::from("e1:public:12345678901234567890123456789012345678901234567890123456789abcd4"),
         ];
-        assert!(parse_webcash_tokens(&valid_public_tokens, &WebcashTokenKind::Public, 100).is_ok());
-        assert!(
-            parse_webcash_tokens(&valid_public_tokens, &WebcashTokenKind::Secret, 100).is_err()
-        );
-        assert!(parse_webcash_tokens(&valid_public_tokens, &WebcashTokenKind::Public, 4).is_ok());
-        assert!(parse_webcash_tokens(&valid_public_tokens, &WebcashTokenKind::Secret, 4).is_err());
-        assert!(parse_webcash_tokens(&valid_public_tokens, &WebcashTokenKind::Public, 3).is_err());
-        assert!(parse_webcash_tokens(&valid_public_tokens, &WebcashTokenKind::Secret, 3).is_err());
+        assert_eq!(parse_secret_webcash(&valid_public_tokens).len(), 0);
+        assert_eq!(parse_public_webcash(&valid_public_tokens).len(), 4);
 
         let valid_mixed_tokens = vec![
             String::from("e0.00000001:secret:12345678901234567890123456789012345678901234567890123456789abcd1"),
@@ -721,12 +726,8 @@ mod tests {
             String::from("e1:secret:12345678901234567890123456789012345678901234567890123456789abcd3"),
             String::from("e1:public:12345678901234567890123456789012345678901234567890123456789abcd4"),
         ];
-        assert!(parse_webcash_tokens(&valid_mixed_tokens, &WebcashTokenKind::Public, 100).is_err());
-        assert!(parse_webcash_tokens(&valid_mixed_tokens, &WebcashTokenKind::Secret, 100).is_err());
-        assert!(parse_webcash_tokens(&valid_mixed_tokens, &WebcashTokenKind::Public, 4).is_err());
-        assert!(parse_webcash_tokens(&valid_mixed_tokens, &WebcashTokenKind::Secret, 4).is_err());
-        assert!(parse_webcash_tokens(&valid_mixed_tokens, &WebcashTokenKind::Public, 3).is_err());
-        assert!(parse_webcash_tokens(&valid_mixed_tokens, &WebcashTokenKind::Secret, 3).is_err());
+        assert_eq!(parse_secret_webcash(&valid_mixed_tokens).len(), 3);
+        assert_eq!(parse_public_webcash(&valid_mixed_tokens).len(), 1);
 
         let valid_secret_tokens_precision = vec![
             String::from("e0.00000001:secret:12345678901234567890123456789012345678901234567890123456789abcd1"),
@@ -734,45 +735,22 @@ mod tests {
             String::from("e1.00000000:secret:12345678901234567890123456789012345678901234567890123456789abcd3"),
             String::from("e1.0000:secret:12345678901234567890123456789012345678901234567890123456789abcd4"),
         ];
-        assert!(
-            parse_webcash_tokens(&valid_secret_tokens_precision, &WebcashTokenKind::Public, 4)
-                .is_err()
-        );
-        assert!(
-            parse_webcash_tokens(&valid_secret_tokens_precision, &WebcashTokenKind::Secret, 4)
-                .is_ok()
-        );
-        assert!(
-            parse_webcash_tokens(&valid_secret_tokens_precision, &WebcashTokenKind::Public, 3)
-                .is_err()
-        );
-        assert!(
-            parse_webcash_tokens(&valid_secret_tokens_precision, &WebcashTokenKind::Secret, 3)
-                .is_err()
-        );
+        assert_eq!(parse_secret_webcash(&valid_secret_tokens_precision).len(), 4);
+        assert_eq!(parse_public_webcash(&valid_secret_tokens_precision).len(), 0);
 
         let total_amount_too_large_tokens = vec![
             String::from("e0.00000001:secret:12345678901234567890123456789012345678901234567890123456789abcd1"),
             String::from("e210000000000:secret:12345678901234567890123456789012345678901234567890123456789abcd2"),
         ];
-        assert!(parse_webcash_tokens(
-            &total_amount_too_large_tokens,
-            &WebcashTokenKind::Public,
-            100
-        )
-        .is_err());
-
-        let zero_tokens: Vec<String> = vec![];
-        assert!(parse_webcash_tokens(&zero_tokens, &WebcashTokenKind::Public, 100).is_err());
+        assert_eq!(parse_secret_webcash(&total_amount_too_large_tokens).len(), 1);
 
         let invalid_tokens = vec![
             String::from("e0.00000001:secret:12345678901234567890123456789012345678901234567890123456789abcd1"),
             String::from("e1:secret:12345678901234567890123456789012345678901234567890123456789abcd3"),
             String::from("e1:secret:12345678901234567890123456789012345678901234567890123456789abcd4"),
-            String::from("e210000000000.00000001:secret:12345678901234567890123456789012345678901234567890123456789abcd2"),
-         ];
-        assert!(parse_webcash_tokens(&invalid_tokens, &WebcashTokenKind::Public, 100).is_err());
-        assert!(parse_webcash_tokens(&invalid_tokens, &WebcashTokenKind::Secret, 100).is_err());
+            String::from("e92233720368.54775808:secret:12345678901234567890123456789012345678901234567890123456789abcd2"),
+        ];
+        assert_eq!(parse_secret_webcash(&invalid_tokens).len(), 3);
 
         let duplicate_hex_1 = vec![
             String::from("e0.00000001:secret:12345678901234567890123456789012345678901234567890123456789abcd1"),
@@ -780,8 +758,8 @@ mod tests {
             String::from("e1:secret:12345678901234567890123456789012345678901234567890123456789abcd3"),
             String::from("e1:secret:12345678901234567890123456789012345678901234567890123456789abcd1"),
         ];
-        assert!(parse_webcash_tokens(&duplicate_hex_1, &WebcashTokenKind::Public, 100).is_err());
-        assert!(parse_webcash_tokens(&duplicate_hex_1, &WebcashTokenKind::Secret, 100).is_err());
+        assert_eq!(parse_secret_webcash(&duplicate_hex_1).len(), 4);
+        assert_eq!(parse_secret_webcash(&duplicate_hex_1).contains_duplicates(), true);
 
         let duplicate_hex_2 = vec![
             String::from("e0.00000001:secret:12345678901234567890123456789012345678901234567890123456789abcd1"),
@@ -789,8 +767,8 @@ mod tests {
             String::from("e1:secret:12345678901234567890123456789012345678901234567890123456789abcd3"),
             String::from("e1:secret:12345678901234567890123456789012345678901234567890123456789abcd4"),
         ];
-        assert!(parse_webcash_tokens(&duplicate_hex_2, &WebcashTokenKind::Public, 100).is_err());
-        assert!(parse_webcash_tokens(&duplicate_hex_2, &WebcashTokenKind::Secret, 100).is_err());
+        assert_eq!(parse_secret_webcash(&duplicate_hex_2).len(), 4);
+        assert_eq!(parse_secret_webcash(&duplicate_hex_2).contains_duplicates(), true);
 
         let duplicate_hex_3 = vec![
             String::from("e0.00000001:secret:12345678901234567890123456789012345678901234567890123456789abcd1"),
@@ -798,37 +776,41 @@ mod tests {
             String::from("e1:secret:12345678901234567890123456789012345678901234567890123456789abcd3"),
             String::from("e1:secret:12345678901234567890123456789012345678901234567890123456789abcd4"),
         ];
-        assert!(parse_webcash_tokens(&duplicate_hex_3, &WebcashTokenKind::Public, 100).is_err());
-        assert!(parse_webcash_tokens(&duplicate_hex_3, &WebcashTokenKind::Secret, 100).is_err());
+        assert_eq!(parse_secret_webcash(&duplicate_hex_3).len(), 4);
+        assert_eq!(parse_secret_webcash(&duplicate_hex_3).contains_duplicates(), true);
+    }
+
+    fn is_webcash_amount(s: &str) -> bool {
+        s.parse::<Amount>().is_ok()
     }
 
     #[test]
     fn test_decimal_from_str() {
-        assert!(Decimal::from_str_exact("Inf").is_err());
-        assert!(Decimal::from_str_exact("-Inf").is_err());
-        assert!(Decimal::from_str_exact("NaN").is_err());
-        assert!(Decimal::from_str_exact("-NaN").is_err());
+        assert!(!is_webcash_amount("Inf"));
+        assert!(!is_webcash_amount("-Inf"));
+        assert!(!is_webcash_amount("NaN"));
+        assert!(!is_webcash_amount("-NaN"));
     }
 
     #[test]
     fn test_is_webcash_amount() {
-        assert!(is_webcash_amount(decimal("0.00000001")));
-        assert!(is_webcash_amount(decimal("1")));
-        assert!(is_webcash_amount(decimal("1.00000001")));
-        assert!(is_webcash_amount(decimal("209999999999.99999999")));
-        assert!(is_webcash_amount(decimal("210000000000")));
+        assert!(is_webcash_amount("0.00000001"));
+        assert!(is_webcash_amount("1"));
+        assert!(is_webcash_amount("1.00000001"));
+        assert!(is_webcash_amount("92233720368.54775807"));
+        assert!(is_webcash_amount("92233720368"));
 
-        assert!(!is_webcash_amount(decimal("0")));
-        assert!(!is_webcash_amount(decimal("0.000000001")));
-        assert!(!is_webcash_amount(decimal("1.000000001")));
-        assert!(!is_webcash_amount(decimal("209999999999.999999989")));
-        assert!(!is_webcash_amount(decimal("210000000000.00000001")));
-        assert!(!is_webcash_amount(decimal("210000000000.1")));
-        assert!(!is_webcash_amount(decimal("210000000001")));
-        assert!(!is_webcash_amount(decimal("-0")));
-        assert!(!is_webcash_amount(decimal("-1")));
-        assert!(!is_webcash_amount(decimal("-1.1")));
-        assert!(!is_webcash_amount(decimal("-210000000000")));
+        assert!(!is_webcash_amount("0"));
+        assert!(!is_webcash_amount("0.000000001"));
+        assert!(!is_webcash_amount("1.000000001"));
+        assert!(!is_webcash_amount("92233720368.547758069"));
+        assert!(!is_webcash_amount("92233720368.54775808"));
+        assert!(!is_webcash_amount("92233720368.6"));
+        assert!(!is_webcash_amount("92233720369"));
+        assert!(!is_webcash_amount("-0"));
+        assert!(!is_webcash_amount("-1"));
+        assert!(!is_webcash_amount("-1.1"));
+        assert!(!is_webcash_amount("-92233720368"));
     }
 
     #[test]
@@ -864,27 +846,77 @@ mod tests {
     }
 
     #[test]
+    fn test_is_public_webcash() {
+        assert!(is_public_webcash(
+            "e1:public:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        ));
+        assert!(is_public_webcash(
+            "e1:public:0ba1c936042f2d6aade5563e9fb319275aec0ee6a262a5a77be01aad99a98cf2"
+        ));
+
+        assert!(!is_public_webcash("e1:public:"));
+        assert!(!is_public_webcash("e1:public:0"));
+        assert!(!is_public_webcash("e1:public:01"));
+        assert!(!is_public_webcash(
+            "e1:public:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde"
+        ));
+        assert!(!is_public_webcash(
+            "e1:public: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        ));
+        assert!(!is_public_webcash(
+            "e1:public:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg"
+        ));
+        assert!(!is_public_webcash(
+            "e1:public:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef "
+        ));
+        assert!(!is_public_webcash(
+            "e1:public:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde "
+        ));
+        assert!(!is_public_webcash(
+            "e1:public:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0"
+        ));
+    }
+
+    #[test]
     fn test_webcash_token_to_string() {
         let tokens: Vec<&str> = vec![
             "e0.00000001:public:12345678901234567890123456789012345678901234567890123456789abcde",
             "e0.00000001:secret:12345678901234567890123456789012345678901234567890123456789abcde",
             "e1:public:12345678901234567890123456789012345678901234567890123456789abcde",
             "e1:secret:12345678901234567890123456789012345678901234567890123456789abcde",
-            "e210000000000.00000000:public:12345678901234567890123456789012345678901234567890123456789abcde",
-            "e210000000000.00000000:secret:12345678901234567890123456789012345678901234567890123456789abcde"
+            "e92233720368.54775807:public:12345678901234567890123456789012345678901234567890123456789abcde",
+               
+            "e92233720368.54775807:secret:12345678901234567890123456789012345678901234567890123456789abcde"
         ];
         for token_string in tokens {
-            let token = parse_webcash_token(token_string).unwrap();
-            assert!(is_webcash_token(&webcash_token_to_string(&token)));
-            assert!(is_webcash_token(&format!("{}", &token)));
-            assert_eq!(webcash_token_to_string(&token), format!("{}", &token));
-            if token.token_kind == WebcashTokenKind::Secret {
-                let public_token = token.to_public();
-                assert_eq!(token.amount, public_token.amount);
-                assert_ne!(token.token_kind, public_token.token_kind);
-                assert_ne!(token.hex_string, public_token.hex_string);
+            let secret = token_string.parse::<SecretWebcash>();
+            let public = token_string.parse::<PublicWebcash>();
+            assert!(secret.is_ok() || public.is_ok());
+            if let Ok(secret) = secret {
+                assert_eq!(secret, secret.to_string().parse::<SecretWebcash>().unwrap());
+                assert_eq!(secret.to_string(), format!("{}", &secret));
+                let public = secret.to_public();
+                assert!(!public.amount.is_none());
+                assert_eq!(public.amount.unwrap(), secret.amount);
+                assert_eq!(public.hash, H256::from_slice(&Sha256::digest(&secret.secret)))
+            }
+            if let Ok(public) = public {
+                assert_eq!(public, public.to_string().parse::<PublicWebcash>().unwrap());
+                assert_eq!(public.to_string(), format!("{}", &public));
             }
         }
+    }
+
+    fn is_public_webcash(s: &str) -> bool {
+        s.parse::<PublicWebcash>().is_ok()
+    }
+
+    fn is_secret_webcash(s: &str) -> bool {
+        s.parse::<SecretWebcash>().is_ok()
+    }
+
+    fn is_webcash_token(s: &str) -> bool {
+        is_public_webcash(s) || is_secret_webcash(s)
     }
 
     #[test]
@@ -921,13 +953,20 @@ mod tests {
             "e0.00000002:secret:12345678901234567890123456789012345678901234567890123456789abcde"
         ));
         assert!(is_webcash_token(
-            "e210000000000:secret:12345678901234567890123456789012345678901234567890123456789abcde"
+            "e92233720368:secret:12345678901234567890123456789012345678901234567890123456789abcde"
         ));
         assert!(is_webcash_token(
-            "e210000000000.0:secret:12345678901234567890123456789012345678901234567890123456789abcde"
+            "e92233720368.5477:secret:12345678901234567890123456789012345678901234567890123456789abcde"
         ));
         assert!(is_webcash_token(
-            "e210000000000.00000000:secret:12345678901234567890123456789012345678901234567890123456789abcde"
+            "e92233720368.54775807:secret:12345678901234567890123456789012345678901234567890123456789abcde"
+        ));
+        assert!(is_webcash_token("e1:secret::"));
+        assert!(is_webcash_token(
+            "1:secret:12345678901234567890123456789012345678901234567890123456789abcde "
+        ));
+        assert!(is_webcash_token(
+            "1:secret:12345678901234567890123456789012345678901234567890123456789abcde:"
         ));
 
         assert!(!is_webcash_token(""));
@@ -935,7 +974,6 @@ mod tests {
         assert!(!is_webcash_token(":::"));
         assert!(!is_webcash_token("e:::"));
         assert!(!is_webcash_token("e1:::"));
-        assert!(!is_webcash_token("e1:secret::"));
         assert!(!is_webcash_token(
             "e1::12345678901234567890123456789012345678901234567890123456789abcde"
         ));
@@ -945,12 +983,6 @@ mod tests {
         ));
         assert!(!is_webcash_token(
             " 1:secret:12345678901234567890123456789012345678901234567890123456789abcde"
-        ));
-        assert!(!is_webcash_token(
-            "1:secret:12345678901234567890123456789012345678901234567890123456789abcde "
-        ));
-        assert!(!is_webcash_token(
-            "1:secret:12345678901234567890123456789012345678901234567890123456789abcde:"
         ));
         assert!(!is_webcash_token(
             "1..00000001:secret:12345678901234567890123456789012345678901234567890123456789abcde"
@@ -1008,27 +1040,27 @@ mod tests {
             "e0.000000011:secret:12345678901234567890123456789012345678901234567890123456789abcde"
         ));
         assert!(!is_webcash_token(
-           "e210000000000.000000000:secret:12345678901234567890123456789012345678901234567890123456789abcde"
+            "e92233720368.547758070:secret:12345678901234567890123456789012345678901234567890123456789abcde"
         ));
         assert!(!is_webcash_token(
-            "e210000000000.00000001:secret:12345678901234567890123456789012345678901234567890123456789abcde"
+            "e92233720368.54775808:secret:12345678901234567890123456789012345678901234567890123456789abcde"
         ));
         assert!(!is_webcash_token(
-           "e2100000000000:secret:12345678901234567890123456789012345678901234567890123456789abcde"
+            "e922337203685.4775807:secret:12345678901234567890123456789012345678901234567890123456789abcde"
         ));
         assert!(!is_webcash_token(
-           "e2100000000000.0000000:secret:12345678901234567890123456789012345678901234567890123456789abcde"
+            "e922337203685477.5807:secret:12345678901234567890123456789012345678901234567890123456789abcde"
         ));
         assert!(!is_webcash_token(
-           "e2100000000000.00000000:secret:12345678901234567890123456789012345678901234567890123456789abcde"
+            "e9223372036854775807:secret:12345678901234567890123456789012345678901234567890123456789abcde"
         ));
     }
 
     #[test]
     fn test_epoch() {
         assert_eq!(epoch(1), 0);
-        assert_eq!(epoch(525_000), 0);
-        assert_eq!(epoch(525_001), 1);
+        assert_eq!(epoch(524_999), 0);
+        assert_eq!(epoch(525_000), 1);
         assert_eq!(epoch(1_069_492), 2);
     }
 
@@ -1036,234 +1068,97 @@ mod tests {
     fn test_mining_amount_per_mining_report_in_epoch() {
         assert_eq!(
             mining_amount_per_mining_report_in_epoch(0),
-            Decimal::new(MINING_AMOUNT_IN_FIRST_EPOCH, 0)
+            MINING_AMOUNT_IN_FIRST_EPOCH
         );
-        assert_eq!(
-            mining_amount_per_mining_report_in_epoch(44),
-            decimal("0.00000001")
-        );
-        assert_eq!(
-            mining_amount_per_mining_report_in_epoch(45),
-            decimal("0.00000001")
-        );
-        assert_eq!(mining_amount_per_mining_report_in_epoch(46), decimal("0"));
-        assert_eq!(mining_amount_per_mining_report_in_epoch(63), decimal("0"));
-        assert_eq!(mining_amount_per_mining_report_in_epoch(64), decimal("0"));
-        assert_eq!(
-            mining_amount_per_mining_report_in_epoch(10_000_000),
-            decimal("0")
-        );
+        assert_eq!(mining_amount_per_mining_report_in_epoch(43), 2);
+        assert_eq!(mining_amount_per_mining_report_in_epoch(44), 1);
+        assert_eq!(mining_amount_per_mining_report_in_epoch(45), 0);
+        assert_eq!(mining_amount_per_mining_report_in_epoch(63), 0);
+        assert_eq!(mining_amount_per_mining_report_in_epoch(64), 0);
+        assert_eq!(mining_amount_per_mining_report_in_epoch(10_000_000), 0);
     }
 
     #[test]
     fn test_mining_amount_for_mining_report() {
-        assert_eq!(mining_amount_for_mining_report(1), decimal("200000"));
-        assert_eq!(mining_amount_for_mining_report(2), decimal("200000"));
-        assert_eq!(mining_amount_for_mining_report(525_000), decimal("200000"));
-        assert_eq!(
-            mining_amount_for_mining_report(525_000 + 1),
-            decimal("100000")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(2 * 525_000),
-            decimal("100000")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(2 * 525_000 + 1),
-            decimal("50000")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(3 * 525_000),
-            decimal("50000")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(3 * 525_000 + 1),
-            decimal("25000")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(4 * 525_000),
-            decimal("25000")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(4 * 525_000 + 1),
-            decimal("12500")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(5 * 525_000),
-            decimal("12500")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(5 * 525_000 + 1),
-            decimal("6250")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(6 * 525_000),
-            decimal("6250")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(6 * 525_000 + 1),
-            decimal("3125")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(7 * 525_000),
-            decimal("3125")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(7 * 525_000 + 1),
-            decimal("1562.5")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(8 * 525_000),
-            decimal("1562.5")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(8 * 525_000 + 1),
-            decimal("781.25")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(9 * 525_000),
-            decimal("781.25")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(9 * 525_000 + 1),
-            decimal("390.625")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(10 * 525_000),
-            decimal("390.625")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(10 * 525_000 + 1),
-            decimal("195.3125")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(10 * 525_000),
-            decimal("390.625")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(20 * 525_000),
-            decimal("0.38146973")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(30 * 525_000),
-            decimal("0.00037253")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(40 * 525_000),
-            decimal("0.00000036")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(41 * 525_000),
-            decimal("0.00000018")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(42 * 525_000),
-            decimal("0.00000009")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(43 * 525_000),
-            decimal("0.00000005")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(44 * 525_000),
-            decimal("0.00000002")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(45 * 525_000),
-            decimal("0.00000001")
-        );
-        assert_eq!(
-            mining_amount_for_mining_report(46 * 525_000),
-            decimal("0.00000001")
-        );
-        assert_eq!(mining_amount_for_mining_report(47 * 525_000), decimal("0"));
-        assert_eq!(mining_amount_for_mining_report(50 * 525_000), decimal("0"));
-        assert_eq!(mining_amount_for_mining_report(100 * 525_000), decimal("0"));
-        assert_eq!(
-            mining_amount_for_mining_report(1000 * 525_000),
-            decimal("0")
-        );
-        assert_eq!(mining_amount_for_mining_report(1_069_352), decimal("50000"));
+        assert_eq!(mining_amount_for_mining_report(1), 200000_00000000);
+        assert_eq!(mining_amount_for_mining_report(2), 200000_00000000);
+        assert_eq!(mining_amount_for_mining_report(525_000 - 1), 200000_00000000);
+        assert_eq!(mining_amount_for_mining_report(525_000), 100000_00000000);
+        assert_eq!(mining_amount_for_mining_report(2 * 525_000 - 1), 100000_00000000);
+        assert_eq!(mining_amount_for_mining_report(2 * 525_000), 50000_00000000);
+        assert_eq!(mining_amount_for_mining_report(3 * 525_000 - 1), 50000_00000000);
+        assert_eq!(mining_amount_for_mining_report(3 * 525_000), 25000_00000000);
+        assert_eq!(mining_amount_for_mining_report(4 * 525_000 - 1), 25000_00000000);
+        assert_eq!(mining_amount_for_mining_report(4 * 525_000), 12500_00000000);
+        assert_eq!(mining_amount_for_mining_report(5 * 525_000 - 1), 12500_00000000);
+        assert_eq!(mining_amount_for_mining_report(5 * 525_000), 6250_00000000);
+        assert_eq!(mining_amount_for_mining_report(6 * 525_000 - 1), 6250_00000000);
+        assert_eq!(mining_amount_for_mining_report(6 * 525_000), 3125_00000000);
+        assert_eq!(mining_amount_for_mining_report(7 * 525_000 - 1), 3125_00000000);
+        assert_eq!(mining_amount_for_mining_report(7 * 525_000), 1562_50000000);
+        assert_eq!(mining_amount_for_mining_report(8 * 525_000 - 1), 1562_50000000);
+        assert_eq!(mining_amount_for_mining_report(8 * 525_000), 781_25000000);
+        assert_eq!(mining_amount_for_mining_report(9 * 525_000 - 1), 781_25000000);
+        assert_eq!(mining_amount_for_mining_report(9 * 525_000), 390_62500000);
+        assert_eq!(mining_amount_for_mining_report(10 * 525_000 - 1), 390_62500000);
+        assert_eq!(mining_amount_for_mining_report(10 * 525_000), 195_31250000);
+        assert_eq!(mining_amount_for_mining_report(20 * 525_000), 19073486);
+        assert_eq!(mining_amount_for_mining_report(30 * 525_000), 18626);
+        assert_eq!(mining_amount_for_mining_report(40 * 525_000), 18);
+        assert_eq!(mining_amount_for_mining_report(41 * 525_000), 9);
+        assert_eq!(mining_amount_for_mining_report(42 * 525_000), 4);
+        assert_eq!(mining_amount_for_mining_report(43 * 525_000), 2);
+        assert_eq!(mining_amount_for_mining_report(44 * 525_000), 1);
+        assert_eq!(mining_amount_for_mining_report(45 * 525_000), 0);
+        assert_eq!(mining_amount_for_mining_report(50 * 525_000), 0);
+        assert_eq!(mining_amount_for_mining_report(100 * 525_000), 0);
+        assert_eq!(mining_amount_for_mining_report(1000 * 525_000), 0);
+        assert_eq!(mining_amount_for_mining_report(1_069_352), 50000_00000000);
     }
 
     #[test]
     fn test_mining_subsidy_amount_for_mining_report() {
-        assert_eq!(mining_subsidy_amount_for_mining_report(1), decimal("10000"));
-        assert_eq!(
-            mining_subsidy_amount_for_mining_report(2 * 525_000),
-            decimal("5000.00")
-        );
-        assert_eq!(
-            mining_subsidy_amount_for_mining_report(5 * 525_000),
-            decimal("625.00")
-        );
-        assert_eq!(
-            mining_subsidy_amount_for_mining_report(8 * 525_000),
-            decimal("78.125")
-        );
-        assert_eq!(
-            mining_subsidy_amount_for_mining_report(10 * 525_000),
-            decimal("19.53125")
-        );
-        assert_eq!(
-            mining_subsidy_amount_for_mining_report(20 * 525_000),
-            decimal("0.01907349")
-        );
-        assert_eq!(
-            mining_subsidy_amount_for_mining_report(30 * 525_000),
-            decimal("0.00001863")
-        );
-        assert_eq!(
-            mining_subsidy_amount_for_mining_report(40 * 525_000),
-            decimal("0.00000002")
-        );
-        assert_eq!(
-            mining_subsidy_amount_for_mining_report(41 * 525_000),
-            decimal("0.00000001")
-        );
-        assert_eq!(
-            mining_subsidy_amount_for_mining_report(42 * 525_000),
-            decimal("0")
-        );
-        assert_eq!(
-            mining_subsidy_amount_for_mining_report(100 * 525_000),
-            decimal("0")
-        );
-        assert_eq!(
-            mining_subsidy_amount_for_mining_report(1000 * 525_000),
-            decimal("0")
-        );
-        assert_eq!(
-            mining_subsidy_amount_for_mining_report(1_069_352),
-            decimal("2500")
-        );
+        assert_eq!(mining_subsidy_amount_for_mining_report(0), 10000_00000000);
+        assert_eq!(mining_subsidy_amount_for_mining_report(1 * 525_000 - 1), 10000_00000000);
+        assert_eq!(mining_subsidy_amount_for_mining_report(1 * 525_000), 5000_00000000);
+        assert_eq!(mining_subsidy_amount_for_mining_report(2 * 525_000 - 1), 5000_00000000);
+        assert_eq!(mining_subsidy_amount_for_mining_report(2 * 525_000), 2500_00000000);
+        assert_eq!(mining_subsidy_amount_for_mining_report(5 * 525_000 - 1), 625_00000000);
+        assert_eq!(mining_subsidy_amount_for_mining_report(5 * 525_000), 312_50000000);
+        assert_eq!(mining_subsidy_amount_for_mining_report(8 * 525_000 - 1), 78_12500000);
+        assert_eq!(mining_subsidy_amount_for_mining_report(8 * 525_000), 39_06250000);
+        assert_eq!(mining_subsidy_amount_for_mining_report(10 * 525_000 - 1), 19_53125000);
+        assert_eq!(mining_subsidy_amount_for_mining_report(10 * 525_000), 9_76562500);
+        assert_eq!(mining_subsidy_amount_for_mining_report(20 * 525_000 - 1), 1907348);
+        assert_eq!(mining_subsidy_amount_for_mining_report(20 * 525_000), 953674);
+        assert_eq!(mining_subsidy_amount_for_mining_report(30 * 525_000 - 1), 1862);
+        assert_eq!(mining_subsidy_amount_for_mining_report(30 * 525_000), 931);
+        assert_eq!(mining_subsidy_amount_for_mining_report(39 * 525_000 - 1), 3);
+        assert_eq!(mining_subsidy_amount_for_mining_report(39 * 525_000), 1);
+        assert_eq!(mining_subsidy_amount_for_mining_report(40 * 525_000 - 1), 1);
+        assert_eq!(mining_subsidy_amount_for_mining_report(40 * 525_000), 0);
+        assert_eq!(mining_subsidy_amount_for_mining_report(41 * 525_000 - 1), 0);
+        assert_eq!(mining_subsidy_amount_for_mining_report(41 * 525_000), 0);
+        assert_eq!(mining_subsidy_amount_for_mining_report(100 * 525_000), 0);
+        assert_eq!(mining_subsidy_amount_for_mining_report(1000 * 525_000), 0);
+        assert_eq!(mining_subsidy_amount_for_mining_report(1_069_352), 2500_00000000);
     }
 
     #[test]
     fn test_total_circulation() {
-        assert_eq!(total_circulation(1), decimal("200000"));
-        assert_eq!(total_circulation(10), decimal("2000000"));
-        assert_eq!(total_circulation(100), decimal("20000000"));
-        assert_eq!(total_circulation(1000), decimal("200000000"));
-        assert_eq!(total_circulation(10000), decimal("2000000000"));
-        assert_eq!(total_circulation(100_000), decimal("20000000000"));
-        assert_eq!(total_circulation(1_000_000), decimal("152500000000"));
-        assert_eq!(
-            total_circulation(10_000_000),
-            decimal("209999608993.52675000")
-        );
-        assert_eq!(
-            total_circulation(100_000_000),
-            decimal("209999999999.99475000")
-        );
-        assert_eq!(
-            total_circulation(1_000_000_000),
-            decimal("209999999999.99475000")
-        );
-
-        assert_eq!(total_circulation(524_999), decimal("104999800000"));
-        assert_eq!(total_circulation(525_000), decimal("105000000000"));
-        assert_eq!(total_circulation(525_001), decimal("105000100000"));
+        assert_eq!(total_circulation(1), 200000_00000000);
+        assert_eq!(total_circulation(10), 2000000_00000000);
+        assert_eq!(total_circulation(100), 20000000_00000000);
+        assert_eq!(total_circulation(1000), 200000000_00000000);
+        assert_eq!(total_circulation(10000), 2000000000_00000000);
+        assert_eq!(total_circulation(100_000), 20000000000_00000000);
+        assert_eq!(total_circulation(1_000_000), 152500000000_00000000);
+        assert_eq!(total_circulation(10_000_000), 209999608993_52125000);
+        assert_eq!(total_circulation(100_000_000), TOTAL_ISSUANCE);
+        assert_eq!(total_circulation(1_000_000_000), TOTAL_ISSUANCE);
+        assert_eq!(total_circulation(524_999), 104999800000_00000000);
+        assert_eq!(total_circulation(525_000), 105000000000_00000000);
+        assert_eq!(total_circulation(525_001), 105000100000_00000000);
     }
 
     #[test]
@@ -1272,17 +1167,14 @@ mod tests {
         let first_zero_reward_epoch;
         loop {
             let reward_in_epoch = mining_amount_per_mining_report_in_epoch(epoch);
-            if reward_in_epoch == decimal("0") {
+            if reward_in_epoch == 0 {
                 first_zero_reward_epoch = epoch;
                 break;
             }
             epoch += 1;
         }
-        assert_eq!(first_zero_reward_epoch, 46);
-        assert_eq!(
-            mining_amount_per_mining_report_in_epoch(first_zero_reward_epoch),
-            decimal("0")
-        );
+        assert_eq!(first_zero_reward_epoch, 45);
+        assert_eq!(mining_amount_per_mining_report_in_epoch(first_zero_reward_epoch), 0);
         assert_ne!(
             total_circulation(first_zero_reward_epoch * MINING_REPORTS_PER_EPOCH - 1),
             total_circulation(first_zero_reward_epoch * MINING_REPORTS_PER_EPOCH)
@@ -1293,22 +1185,20 @@ mod tests {
         );
         assert_eq!(
             total_circulation(first_zero_reward_epoch * MINING_REPORTS_PER_EPOCH),
-            decimal("209999999999.99475000")
+            209999999999_92650000
         );
     }
 
     #[test]
     fn test_total_mining_amount() {
-        let mut total_mining_amount = Decimal::default();
+        let mut total_mining_amount: u128 = 0;
         for epoch in 0..=100 {
             let per_mining_report_mining_amount = mining_amount_per_mining_report_in_epoch(epoch);
-            total_mining_amount += per_mining_report_mining_amount
-                * Decimal::new(i64::from(MINING_REPORTS_PER_EPOCH), 0);
+            total_mining_amount += (per_mining_report_mining_amount * MINING_REPORTS_PER_EPOCH as u64) as u128;
         }
-        assert_eq!(total_mining_amount, decimal("209999999999.99475000"));
+        assert_eq!(total_mining_amount, 209999999999_92650000);
         assert_eq!(total_mining_amount, total_circulation(4_294_967_295));
-        let missing_webcash = Decimal::new(MAX_WEBCASH, 0) - total_mining_amount;
-        assert_eq!(missing_webcash, decimal("0.00525000"));
+        assert_eq!(TOTAL_ISSUANCE - total_mining_amount, 0);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,12 @@ impl std::iter::Sum for Amount {
 
 impl std::convert::From<u64> for Amount {
     fn from(n: u64) -> Self {
-        assert!(1 <= n);
+        // Disabling this check for now, as the server is currently written in
+        // such a way that Amounts are often initialized with zero.  Indedd in
+        // many contexts this makes sense to do (e.g. initializing a sum
+        // accumulator).  We shoudl assess whether implementing this constraint
+        // is worth it.
+        // assert!(1 <= n);
         assert!(n <= MAX_WEBCASH);
         Amount { value: n }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,7 @@ impl std::fmt::Display for Amount {
                     break;
                 }
             }
-            // Combine inteer and fractional parts
+            // Combine integer and fractional parts
             write!(fmt, "{}.{}", divmod.0, frac)
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2022 Webcash Developers
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 use thousands::Separable;
 #[macro_use]
 extern crate log;
@@ -1306,3 +1311,5 @@ mod tests {
         assert_eq!(missing_webcash, decimal("0.00525000"));
     }
 }
+
+// End of File


### PR DESCRIPTION
My apologies for not splitting this into multiple git commits. It was a complete rewrite and it would take a lot of work to isolate the individual changes.

This PR changes the webcash crate API to be more type safe, pulling various settings into the type system itself. For example, it creates a `Amount` struct to store webcash amounts, with checked arithmetic and range-checking constructors (instead of the `rust-decimal` dependency, which is removed), and splits `WebcashToken` into separate `SecretWebcash` and `PublicWebcash` structs. Arrays of webcash values are serialized directly by the JSON serializer rather than having a bunch of specialized parsing functions. Finally, I attempted to use the standard library traits wherever possible to implement things like serialization to/from string representation, summing up a vector, etc.

In addition, there were a couple of behavior-modifying changes made. Webcash allows for any arbitrary Unicode string to be used as the secret value, not just serialized hash values. An off-by-one error with respect to epoch calculations was fixed, which resulted in a different total issuance.

This PR isn't merge ready yet. Tests pass but webcashd panics on start. Still got some work to do.